### PR TITLE
Reduce evaluation numEpochs in production and staging configurations

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -14,7 +14,7 @@
 			"numEpochs": 10000000
 		},
 		"evaluation": {
-			"numEpochs": 100000,
+			"numEpochs": 10000,
 			"timeout": 10000
 		}
 	}

--- a/config/staging.json
+++ b/config/staging.json
@@ -14,7 +14,7 @@
 			"numEpochs": 10000000
 		},
 		"evaluation": {
-			"numEpochs": 100000,
+			"numEpochs": 10000,
 			"timeout": 10000
 		}
 	}


### PR DESCRIPTION
Adjust the evaluation `numEpochs` from 100000 to 10000 to optimize performance in production and staging environments.