### PR TITLE
Increase maximum request size limits

### DIFF
--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -45,7 +45,8 @@ logger.info(`Node environment: ${NODE_ENV}`)
 
 // Middleware
 app.use(helmet()) // Security headers
-app.use(express.json()) // for parsing application/json
+app.use(express.json({ limit: '50mb' }))
+app.use(express.urlencoded({ limit: '50mb', extended: true }))
 
 // Apply cors config to all routes
 app.use(cors(corsConfig))


### PR DESCRIPTION
Adjust the JSON and URL-encoded body parser middleware to allow a maximum size of 50mb for incoming requests.